### PR TITLE
Improve parsing

### DIFF
--- a/statblock-converter/scripts/sbcParser.js
+++ b/statblock-converter/scripts/sbcParser.js
@@ -35,7 +35,7 @@ export class sbcParser {
             .replace(/⅙/gm, "1/6")
             .replace(/⅛/gm, "1/8")
             // Remove Source Superscript (e.g. ^APG, ^UE)
-            .replace(/(APG\b|ACG\b|UE\b|UM\b|HA\b|OA\b|ISWG\b|B\b)/gm, "")
+            .replace(/(APG\b|ACG\b|UE\b|UM\b|HA\b|OA\b|ISWG\b|[^CM]B\b)/gm, "")
             // Replace common Skill shorthands and misswordings
             .replace(/\bEnter Choice\b/igm, "any one")
             .replace(/Arcane/igm, "Arcana")

--- a/statblock-converter/scripts/sbcParsers.js
+++ b/statblock-converter/scripts/sbcParsers.js
@@ -1908,6 +1908,10 @@ export async function parseOffense(data, startLine) {
                     parsedSubCategories["specialAttacks"] = await parserSpecialAttacks.parse(specialAttacks, line+startLine)
                 }
             }
+
+            // Spellcasting support functions
+            const getConcentrationBonus = (line) => line.match(/\b(Concentration\b|Conc\.)\s*\+(?<bonus>\d+)/i)?.groups.bonus;
+
                     
             // Parse Spell-Like Abilities
             if (!parsedSubCategories["spellLikeAbilities"]) {
@@ -1930,15 +1934,12 @@ export async function parseOffense(data, startLine) {
 
                     // Set casterLevel and concentrationBonus
                     let casterLevel = 0
-                    let concentrationBonus = 0
 
                     if (lineContent.match(/\bCL\b\s*(\d+)/i) !== null) {
                         casterLevel = lineContent.match(/\bCL\b\s*(\d+)/i)[1]
                     }
 
-                    if (lineContent.match(/\bConcentration\b\s*\+(\d+)/i) !== null) {
-                        concentrationBonus = lineContent.match(/\bConcentration\b\s*\+(\d+)/i)[1]
-                    }
+                    let concentrationBonus = getConcentrationBonus(lineContent) ?? 0;
 
                     // Push the line into the array holding the raw data for Spell-Like Abilities
                     rawSpellBooks[spellBooksFound] = {
@@ -1993,16 +1994,12 @@ export async function parseOffense(data, startLine) {
                     sbcData.notes.offense.hasSpellcasting = true
 
                     let casterLevel = 0
-                    let concentrationBonus = 0
 
                     if (lineContent.match(/\bCL\b\s*(\d+)/i) !== null) {
                         casterLevel = lineContent.match(/\bCL\b\s*(\d+)/i)[1]
                     }
+                    const concentrationBonus = getConcentrationBonus(lineContent) ?? 0;
 
-                    if (lineContent.match(/\bConcentration\b\s*\+(\d+)/i) !== null) {
-                        concentrationBonus = lineContent.match(/\bConcentration\b\s*\+(\d+)/i)[1]
-                    }
-                    
                     // Push the line into the array holding the raw data for Spell-Like Abilities
                     rawSpellBooks[spellBooksFound] = {
                         "firstLine": lineContent,
@@ -2043,7 +2040,7 @@ export async function parseOffense(data, startLine) {
 
                     let spellCastingType = "spontaneous"
                     let casterLevel = 0
-                    let concentrationBonus = 0
+                    let concentrationBonus = getConcentrationBonus(lineContent) ?? 0;
                     let spellCastingClass = "hd"
                     let isAlchemist = false
 
@@ -2057,10 +2054,6 @@ export async function parseOffense(data, startLine) {
 
                     if (lineContent.match(/\bCL\b\s*(\d+)/i) !== null) {
                         casterLevel = lineContent.match(/\bCL\b\s*(\d+)/i)[1]
-                    }
-
-                    if (lineContent.match(/\bConcentration\b\s*\+(\d+)/i) !== null) {
-                        concentrationBonus = lineContent.match(/\bConcentration\b\s*\+(\d+)/i)[1]
                     }
 
                     let patternSupportedClasses = new RegExp("(" + sbcConfig.classes.join("\\b|\\b") + ")", "gi")

--- a/statblock-converter/scripts/sbcParsers.js
+++ b/statblock-converter/scripts/sbcParsers.js
@@ -1910,6 +1910,7 @@ export async function parseOffense(data, startLine) {
             }
 
             // Spellcasting support functions
+            const getCasterLevel = (line) => line.match(/\bCL\b\s*(?<cl>\d+)/i)?.groups.cl;
             const getConcentrationBonus = (line) => line.match(/\b(Concentration\b|Conc\.)\s*\+(?<bonus>\d+)/i)?.groups.bonus;
 
                     
@@ -1933,12 +1934,7 @@ export async function parseOffense(data, startLine) {
                     startIndexOfSpellLikeAbilities = line
 
                     // Set casterLevel and concentrationBonus
-                    let casterLevel = 0
-
-                    if (lineContent.match(/\bCL\b\s*(\d+)/i) !== null) {
-                        casterLevel = lineContent.match(/\bCL\b\s*(\d+)/i)[1]
-                    }
-
+                    let casterLevel = casterLevel = getCasterLevel(lineContent) ?? 0;
                     let concentrationBonus = getConcentrationBonus(lineContent) ?? 0;
 
                     // Push the line into the array holding the raw data for Spell-Like Abilities
@@ -1993,11 +1989,7 @@ export async function parseOffense(data, startLine) {
 
                     sbcData.notes.offense.hasSpellcasting = true
 
-                    let casterLevel = 0
-
-                    if (lineContent.match(/\bCL\b\s*(\d+)/i) !== null) {
-                        casterLevel = lineContent.match(/\bCL\b\s*(\d+)/i)[1]
-                    }
+                    const casterLevel = getCasterLevel(lineContent) ?? 0;
                     const concentrationBonus = getConcentrationBonus(lineContent) ?? 0;
 
                     // Push the line into the array holding the raw data for Spell-Like Abilities
@@ -2039,37 +2031,22 @@ export async function parseOffense(data, startLine) {
                     // Set spellCastingClass (hd is default)
 
                     let spellCastingType = "spontaneous"
-                    let casterLevel = 0
+                    let casterLevel = getCasterLevel(lineContent) ?? 0;
                     let concentrationBonus = getConcentrationBonus(lineContent) ?? 0;
                     let spellCastingClass = "hd"
-                    let isAlchemist = false
+                    let isAlchemist = /Extracts/i.test(lineContent);
 
-                    if (lineContent.match(/Extracts/i) !== null) {
-                        isAlchemist = true
-                    }
-
-                    if (lineContent.match(/prepared/i) !== null) {
+                    if (/prepared/i.test(lineContent)) {
                         spellCastingType = "prepared"
-                    }
-
-                    if (lineContent.match(/\bCL\b\s*(\d+)/i) !== null) {
-                        casterLevel = lineContent.match(/\bCL\b\s*(\d+)/i)[1]
                     }
 
                     let patternSupportedClasses = new RegExp("(" + sbcConfig.classes.join("\\b|\\b") + ")", "gi")
                     let patternPrestigeClasses = new RegExp("(" + sbcConfig.prestigeClassNames.join("\\b|\\b") + ")(.*)", "gi")
                     let patternWizardClasses = new RegExp("(" + sbcContent.wizardSchoolClasses.join("\\b|\\b") + ")(.*)", "gi")
 
-                    if (lineContent.match(patternSupportedClasses) !== null) {
-                        spellCastingClass = lineContent.match(patternSupportedClasses)[0]
-                    }
-
-                    if (lineContent.match(patternPrestigeClasses) !== null) {
-                        spellCastingClass = lineContent.match(patternPrestigeClasses)[0]
-                    }
-
-                    if (lineContent.match(patternWizardClasses) !== null) {
-                        spellCastingClass = lineContent.match(patternWizardClasses)[0]
+                    let castingClass = lineContent.match(patternSupportedClasses) ?? lineContent.match(patternPrestigeClasses) ?? lineContent.match(patternWizardClasses);
+                    if (castingClass !== null) {
+                        spellCastingClass = castingClass[0]
                     }
 
                     // Push the line into the array holding the raw data for spellBook

--- a/statblock-converter/scripts/sbcParsers.js
+++ b/statblock-converter/scripts/sbcParsers.js
@@ -3209,11 +3209,7 @@ export async function parseStatistics(data, startLine) {
                     let parserCmb = sbcMapping.map.statistics.cmb
                     let cmbRaw = lineContent.match(/(?:CMB\b)(.*)(?=\bCMD)/i)[1].trim()
 
-                    let cmb = 0
-
-                    if (cmbRaw.match(/(\d+)/) !== null) {
-                        cmb = cmbRaw.match(/([\+\-]?\d+)/)[0]
-                    }
+                    let cmb = cmbRaw.match(/([+-]?\d+)/)?.[0] ?? 0;
 
                     let cmbContext = sbcUtils.parseSubtext(cmbRaw)[1]
 

--- a/statblock-converter/scripts/sbcParsers.js
+++ b/statblock-converter/scripts/sbcParsers.js
@@ -3231,12 +3231,8 @@ export async function parseStatistics(data, startLine) {
                     let cmdRaw = lineContent.match(/(?:CMD\b)(.*)/i)[1].trim()
 
                     // Check if CMD is "-"
-                    let cmd = 0
+                    let cmd = cmdRaw.match(/(\d+)/)?.[0] ?? 0;
 
-                    if (cmdRaw.match(/(\d+)/) !== null) {
-                        cmd = cmdRaw.match(/(\d+)/)[0]
-                    }
-                    
                     let cmdContext = sbcUtils.parseSubtext(cmdRaw)[1]
 
                     sbcData.characterData.actorData.data.data.attributes.cmdNotes = cmdContext

--- a/statblock-converter/scripts/sbcUtils.js
+++ b/statblock-converter/scripts/sbcUtils.js
@@ -551,10 +551,12 @@ export class sbcUtils {
 
                 let spellCastingAbility = actor.data.data.attributes.spells.spellbooks[spellBookToValidate].ability
                 let spellCastingAbilityModifier = actor.data.data.abilities[spellCastingAbility].mod
+                
+                const concentrationBonusOnActor = actor.data.data.attributes.spells.spellbooks[spellBookToValidate].concentration.total;
 
                 let differenceInCasterLevel = +casterLevelToValidate - +casterLevelInActor
-                let differenceInConcentrationBonus = +concentrationBonusToValidate - +casterLevelToValidate + +spellCastingAbilityModifier
-
+                let differenceInConcentrationBonus = +concentrationBonusToValidate - concentrationBonusOnActor
+                
                 if (differenceInCasterLevel !== 0) {
                     await actor.update({
                         "data": {


### PR DESCRIPTION
This fixes small parsing errors and simplifies some regexp to no longer repeatedly reparse the same thing.

Fixes:
- Concentration bonus missing in some cases
- CMB being turned to CM and thus failing to be parsed

Fixes #508