### PR TITLE
Reinit only on new instance

### DIFF
--- a/statblock-converter/scripts/sbc.js
+++ b/statblock-converter/scripts/sbc.js
@@ -31,7 +31,7 @@ export class sbcApp {
     /* Reset and re-initialize sbc          */
     /* ------------------------------------ */
 
-    static async resetSBC() {
+    static async resetSBC(reinit=true) {
         sbcConfig.options.debug && sbcUtils.log("Reset");
 
         // Reset data
@@ -50,7 +50,7 @@ export class sbcApp {
         sbcUtils.resetFlags();
 
         // Initialize sbc again
-        await this.initializeSBC();
+        if (reinit) await this.initializeSBC();
         
     }
 
@@ -161,12 +161,5 @@ Hooks.on("renderActorDirectory", (app, html, data) => {
 
 // When the inputDialog gets closed, reset sbc
 Hooks.on("closesbcInputDialog", (app, html, data) => {
-    sbcApp.resetSBC()
+    sbcApp.resetSBC(false)
 })
-
-
-
-
-
-
-

--- a/statblock-converter/scripts/sbcInput.js
+++ b/statblock-converter/scripts/sbcInput.js
@@ -36,6 +36,7 @@ export class sbcInputDialog extends Application {
     static sbcInputDialogInstance = {}
     
     static async renderInputDialog() {
+        sbcApp.resetSBC(true);
  
         sbcInputDialog.sbcInputDialogInstance = new sbcInputDialog()
         sbcData.actorType = +sbcConfig.options.defaultActorType
@@ -175,7 +176,7 @@ export class sbcInputDialog extends Application {
                         //await newActor.update({})
         
                         sbcInputDialog.sbcInputDialogInstance.close()
-                        sbcApp.resetSBC()
+                        sbcApp.resetSBC(false)
                     } catch (err) {
                         throw err
                     }


### PR DESCRIPTION
Re-initializes only when new instance is started.

Doesn't affect much. Mostly removes the initialization of temp actor when SBC closes, which is kinda weird time to do it, and was causing some confusing debug output elsewhere due to it.