### PR TITLE
Remove ^UC superscript as well

### DIFF
--- a/statblock-converter/scripts/sbcParser.js
+++ b/statblock-converter/scripts/sbcParser.js
@@ -35,7 +35,7 @@ export class sbcParser {
             .replace(/⅙/gm, "1/6")
             .replace(/⅛/gm, "1/8")
             // Remove Source Superscript (e.g. ^APG, ^UE)
-            .replace(/(APG\b|ACG\b|UE\b|UM\b|HA\b|OA\b|ISWG\b|[^CM]B\b)/gm, "")
+            .replace(/(APG\b|ACG\b|U[CEM]\b|HA\b|OA\b|ISWG\b|[^CM]B\b)/gm, "")
             
             // Replace ligatures
             .replace(/ﬂ/igm, "fl")


### PR DESCRIPTION
Everything involving firearms usually has <sup>UC</sup> appended, for example.